### PR TITLE
:rocket: main 브랜치에 병합시 자동으로 storybook 배포 CI 구현

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -5,11 +5,43 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Node.js 설치
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: yarn-deps-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-deps-${{ hashFiles('yarn.lock') }}
+
+      - name: Chromatic에 배포
+        id: chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          onlyChanged: true
+          autoAcceptChanges: true
+
+  vercel:
     runs-on: ubuntu-latest
     container: pandoc/latex
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Install mustache (to update the date)
         run: apk add ruby && gem install mustache
       - name: creates output
@@ -28,3 +60,14 @@ jobs:
           target-branch: main
       - name: Test get variable exported by push-to-another-repository
         run: echo $DESTINATION_CLONED_DIRECTORY
+
+  github-bot:
+    runs-on: ubuntu-latest
+    needs: [chromatic, vercel]
+    steps:
+      - name: PR 코멘트로 Preview URL 남기기
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            Storybook url: ${{ needs.chromatic.outputs.storybook_url }}
+            vercel url: ${{ needs.vercel.outputs.vercel_url }}


### PR DESCRIPTION
# 🚅 Issue 번호

# 🤷 Issue 세부 내용
 main 브랜치에 병합시 자동으로 storybook 배포 CI 구현하기 위해 github action을 수정하였습니다. 

# ✨ 기대 결과
어떤 결과물을 원하시나요?
main 브랜치에 병합하면 바로 배포되길 원합니다. 

# 📸 스크린샷 및 gif (필수)
이슈에 해당하는 부분을 보여주세요.

# 👩‍💻 공유 포인트 및 논의 사항

- github action은 커스텀 액션이 가능하다는 장점이 있다.
- Job이란 독립된 환경에서 돌아가는 하나의 처리 단위를 말한다.
- Job 안에 runs-on과 steps는 필수이다. 

```
jobs:
  setup:
    name: Setup Job
  dialyzer:
    needs: setup
    name: Mix Dialyzer
  test:
    needs: setup
    name: Mix Test
  build:
    needs: setup
    name: Application Build
```
이런식으로 jobs를 구성하면 병렬적으로 빌드할 수 있어 빌드 타임을 줄일 수 있다고 한다. 

# 💣 예상되는 이슈 
vercel jobs에서 vercel의 url을 받아오지 못할 것으로 예상합니다. vercel CLI를 활용하여 배포한것이 아니라 개인 레포로 푸쉬하는 역할을 수행하고 있습니다. 병합 후, 확인해야할 것 같아요.

