### PR TITLE
[FIX] 테스트 progress bar가 이전 상태를 기억하지 못하지 못하는 에러 해결

### DIFF
--- a/src/app/test/_components/TestForm.tsx
+++ b/src/app/test/_components/TestForm.tsx
@@ -22,15 +22,12 @@ export type StepProps = Range<0, 12>;
 const TestForm = () => {
   const router = useRouter();
   const [state, dispatch] = useReducer(reducer, initialState);
-  console.log('state', state);
   const [step, setStep] = useState<StepProps>(0);
 
   const handleChangeStep = (index: StepProps) => {
     if (index === QUESTIONS_ORDERS.lastPage) router.push('/test/result');
     setStep((index + 2) as StepProps);
   };
-
-  const totalPages = QUESTIONS_ORDERS_LENGTH;
 
   return (
     <>
@@ -87,9 +84,9 @@ const TestForm = () => {
                 image={QUESTIONS[index].image}
                 badgeStatus={
                   QUESTIONS[index].badgeStatus ||
-                  `${QUESTIONS[index].progress - PRE_QUESTIONS_LENGTH}/${totalPages - PRE_QUESTIONS_LENGTH}`
+                  `${step - PRE_QUESTIONS_LENGTH}/${QUESTIONS_ORDERS_LENGTH - PRE_QUESTIONS_LENGTH}`
                 }
-                progress={(QUESTIONS[index].progress / totalPages) * 100}
+                progress={(step / QUESTIONS_ORDERS_LENGTH) * 100}
                 onChangeStep={() => handleChangeStep(index as StepProps)}
                 answerList={QUESTIONS[index].answerList}
               />

--- a/src/app/test/_components/TestQuestionTemplate.tsx
+++ b/src/app/test/_components/TestQuestionTemplate.tsx
@@ -61,7 +61,6 @@ const TestQuestionTemplate = ({
         footer={
           <div className=" flex flex-col gap-3xs">
             {answerList.map((answer, index) => {
-              console.log('answer', answer);
               return (
                 <Button
                   variant={'secondary'}

--- a/src/components/common/progressBar/ProgressBar.tsx
+++ b/src/components/common/progressBar/ProgressBar.tsx
@@ -2,6 +2,7 @@ import { VariantProps } from 'class-variance-authority';
 import { motion } from 'framer-motion';
 import { HTMLAttributes } from 'react';
 
+import { PROGRESSRATE } from '@/constants/test/progress';
 import { cn } from '@/lib/core';
 
 import { ProgressBarContainerVariants } from './variant';
@@ -18,6 +19,8 @@ export const ProgressBar = ({ progress, width, ...props }: ProgressBarProps) => 
         <motion.div
           className="absolute inset-y-0 -left-full right-full -translate-x-full rounded-lg bg-primary-700"
           animate={{ x: `${progress}%` }}
+          // TODO : 현재 뒤로가기시 애니메이션이 어색하여 리팩토링 예정 기존 0에서 시작하는 에러는 해결
+          initial={{ x: `${progress - PROGRESSRATE}%` }}
           transition={{ type: 'tween', duration: 0.5, delay: 0.2 }}
         />
       </div>

--- a/src/constants/test/progress.ts
+++ b/src/constants/test/progress.ts
@@ -1,2 +1,4 @@
 export const QUESTIONS_ORDERS_LENGTH = 11;
 export const PRE_QUESTIONS_LENGTH = 2;
+
+export const PROGRESSRATE = (1 / QUESTIONS_ORDERS_LENGTH) * 100

--- a/src/constants/test/step.tsx
+++ b/src/constants/test/step.tsx
@@ -8,7 +8,6 @@ type Question = {
   badgeStatus?: string;
   question: ReactNode;
   image: string;
-  progress: number;
   answerList: string[];
 };
 
@@ -29,7 +28,6 @@ export const QUESTIONS: Question[] = [
       </>
     ),
     image: `/images/testWorry.png`,
-    progress: 1,
     answerList: ['남성', '여성'],
   },
   {
@@ -43,7 +41,7 @@ export const QUESTIONS: Question[] = [
       </>
     ),
     image: `/images/testWorry.png`,
-    progress: 2,
+
     answerList: ['10대', '20대', '30대', '40대'],
   },
   {
@@ -56,7 +54,7 @@ export const QUESTIONS: Question[] = [
       </>
     ),
     image: `/images/testWorry.png`,
-    progress: 3,
+
     answerList: ['예', '아니요'],
   },
   {
@@ -69,7 +67,7 @@ export const QUESTIONS: Question[] = [
       </>
     ),
     image: `/images/testWorry.png`,
-    progress: 4,
+
     answerList: ['창피하지만 인사정도 나눌 수 있다.', '조용히 최대한 피한다.'],
   },
   {
@@ -83,7 +81,7 @@ export const QUESTIONS: Question[] = [
       </>
     ),
     image: `/images/testWorry.png`,
-    progress: 5,
+
     answerList: ['상대방 결혼식에 참석해 얼굴 비춘다.', '미안하지만 송금으로 마음을 전한다.'],
   },
   {
@@ -95,7 +93,7 @@ export const QUESTIONS: Question[] = [
       </>
     ),
     image: `/images/testWorry.png`,
-    progress: 6,
+
     answerList: ['예', '아니오'],
   },
   {
@@ -107,7 +105,7 @@ export const QUESTIONS: Question[] = [
       </>
     ),
     image: `/images/testWorry.png`,
-    progress: 7,
+
     answerList: ['연락해서 축하라도 해줘야겠다.', '알아서 잘 보내겠지라는 생각으로 넘긴다.'],
   },
   {
@@ -120,7 +118,7 @@ export const QUESTIONS: Question[] = [
       </>
     ),
     image: `/images/testWorry.png`,
-    progress: 8,
+
     answerList: ['예전부터 이상형이 한결 같다.', '왜 나에게 인사를 시켜주는 지 모르겠다.'],
   },
   {
@@ -133,7 +131,7 @@ export const QUESTIONS: Question[] = [
       </>
     ),
     image: `/images/testWorry.png`,
-    progress: 9,
+
     answerList: ['예', '아니오'],
   },
   {
@@ -145,7 +143,7 @@ export const QUESTIONS: Question[] = [
       </>
     ),
     image: `/images/testWorry.png`,
-    progress: 10,
+
     answerList: [
       '무슨 사정이 있겠지. 연락오기를 기다린다.',
       '잠수탄 것 아닐까? 의심하며 귀가 준비한다.',
@@ -162,7 +160,7 @@ export const QUESTIONS: Question[] = [
       </>
     ),
     image: `/images/testWorry.png`,
-    progress: 11,
+
     answerList: [
       '어떻게 쓸 지 고민되지만 연락줘서 고맙다.',
       '쓸 말이 없어 막막하고 스트레스 받는다.',


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## ✨ 작업 내용
### 해결 과정 
- 구조를 변경하여 progressBar 컴포넌트가 unMount되지 않도록 구조를 변경하려고 시도하였습니다.
- 정확히 원인을 분석해보니 ProgressBar 디자인 시스템에 애니메이션을 추가한 이후 이슈라는 것을 파악하였습니다. 
- 애니메이션 initial props가 있다는 것을 발견하고 테스트가 하나씩 진행될때 받은 Progress에 이전 위치에서 애니메이션이 시작되도록 구현하였습니다.

close #102 



<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 📚 작업 결과

https://github.com/dnd-side-project/dnd-10th-3-frontend/assets/93697790/7edb9270-4fad-46b8-b30a-619c215e9e29


<!-- 없다면 적지 않으셔도 됩니다. -->
<!-- 사진이 있다면 함께 첨부해 주세요 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

## ✅ PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone을 등록했습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.
