### PR TITLE
[BUGFIX] useSearchParams 관련 배포 이슈 해결

### DIFF
--- a/src/app/login/oauth2/code/kakao/page.tsx
+++ b/src/app/login/oauth2/code/kakao/page.tsx
@@ -1,7 +1,13 @@
+import { Suspense } from 'react';
+
 import KakaoLogin from './_components/KakaoLogin';
 
 const page = () => {
-  return <KakaoLogin />;
+  return (
+    <Suspense>
+      <KakaoLogin />
+    </Suspense>
+  );
 };
 
 export default page;

--- a/src/app/vote/_component/VoteHeader.tsx
+++ b/src/app/vote/_component/VoteHeader.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+
 import { Tabs } from '@/components/common/tabs';
 import { Header } from '@/components/layout/header';
 import { CATEGORY_TAB } from '@/constants/category';
@@ -12,7 +14,9 @@ const VoteHeader = () => {
       </Header>
 
       <div className="sticky top-[68px] z-30 bg-white">
-        <Tabs tabItems={CATEGORY_TAB} />
+        <Suspense>
+          <Tabs tabItems={CATEGORY_TAB} />
+        </Suspense>
       </div>
     </>
   );

--- a/src/components/common/tabs/Tabs.stories.tsx
+++ b/src/components/common/tabs/Tabs.stories.tsx
@@ -1,11 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { useState } from 'react';
 
 import { CATEGORY_TAB } from '@/constants/category';
 import { MYPAGE_TAB } from '@/constants/mypage';
 
 import { Tabs } from '.';
-import { Tab } from './Tabs';
 
 const meta = {
   title: 'Components/common/tabs',
@@ -16,41 +14,28 @@ export default meta;
 
 type Story = StoryObj<typeof Tabs>;
 
-// FIXME: Tabs 내부 useSearchParams 호출로 인해 스토리북에서 Tabs를 사용할 수 없어 Tab만을 활용해 임시 구현
-const CategoryTabExample = () => {
-  const [selectedTab, setSelectedTab] = useState('all');
-
-  return (
-    <nav className="no-scrollbar flex shrink-0 gap-3xs overflow-x-scroll scroll-smooth border-b border-gray-100 px-2xs">
-      {CATEGORY_TAB.map((item) => (
-        <button key={item.name} onClick={() => setSelectedTab(item.params)} className="flex">
-          <Tab item={item} isSelected={selectedTab === item.params} />
-        </button>
-      ))}
-    </nav>
-  );
-};
-
 export const CategoryTabs: Story = {
-  render: () => <CategoryTabExample />,
-};
-
-const MypageTabExample = () => {
-  const [selectedTab, setSelectedTab] = useState('vote');
-
-  return (
-    <nav className="no-scrollbar flex shrink-0 gap-3xs overflow-x-scroll scroll-smooth border-b border-gray-100 px-2xs">
-      {MYPAGE_TAB.map((item) => (
-        <>
-          <button key={item.name} onClick={() => setSelectedTab(item.params)} className="flex">
-            <Tab key={item.name} item={item} isSelected={selectedTab === item.params} />
-          </button>
-        </>
-      ))}
-    </nav>
-  );
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      pathname: '/',
+      query: {
+        tab: ['all', 'money', 'clothes', 'bridal-shower', 'other'],
+      },
+    },
+  },
+  render: () => <Tabs tabItems={CATEGORY_TAB} />,
 };
 
 export const MypageTabs: Story = {
-  render: () => <MypageTabExample />,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      pathname: '/',
+      query: {
+        tab: ['test', 'vote'],
+      },
+    },
+  },
+  render: () => <Tabs tabItems={MYPAGE_TAB} />,
 };


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

- useSearchParams 훅을 사용하는 컴포넌트 (KakaoLogin, VoteHeader에 있는 Tabs)를 Suspense로 래핑했습니다.
  - [공식 문서](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout) 참고
- Tabs 스토리에서 useSearchParams 때문에 렌더링하지 못하는 이슈가 있었는데, Story에 nextjs 관련 parameter를 설정하여 렌더링 가능하도록 수정했습니다.

## 📚 작업 결과

<!-- 없다면 적지 않으셔도 됩니다. -->
<!-- 사진이 있다면 함께 첨부해 주세요 -->

close #126 

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

## ✅ PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone을 등록했습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.
