### PR TITLE
[FEAT] 테스트 결과 페이지 로딩 LCP 1초에서 0.02초로 감축 

### DIFF
--- a/src/app/test/result/[id]/_components/ResultContents.tsx
+++ b/src/app/test/result/[id]/_components/ResultContents.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link';
 
 import { Button } from '@/components/common/button';
-import { Spinner } from '@/components/common/spinner';
 import { VoteCard, VoteItem } from '@/components/features/vote';
 import { Header } from '@/components/layout/header';
 import { Typography } from '@/foundations/typography';
@@ -27,54 +26,53 @@ const ResultContents = ({ id }: { id: number }) => {
       <main className="pb-10">
         <section className="flex flex-col items-center justify-center">
           {/* TODO : 컴포넌트 분리 예정 */}
-          {resultData && (
-            <article className="flex flex-col items-center justify-center px-2xs">
-              <ImageBox temperature={resultData.temperature} />
-            </article>
-          )}
 
           {resultData && (
-            <article className="my-4xs flex w-full px-2xs">
-              <div className="flex w-full flex-col items-center justify-center  rounded-xl border  border-gray-100 py-xs">
-                <Typography type="body2" className="mb-5xs w-[240px] text-center text-gray-1000">
-                  &quot;{resultData.title}&quot;
-                </Typography>
-                <Typography type="body3" className="w-[240px] text-center text-gray-600">
-                  {resultData.description}
-                </Typography>
+            <>
+              <article className="flex flex-col items-center justify-center px-2xs">
+                <ImageBox temperature={resultData.temperature} />
+              </article>
+
+              <article className="my-4xs flex w-full px-2xs">
+                <div className="flex w-full flex-col items-center justify-center  rounded-xl border  border-gray-100 py-xs">
+                  <Typography type="body2" className="mb-5xs w-[240px] text-center text-gray-1000">
+                    &quot;{resultData.title}&quot;
+                  </Typography>
+                  <Typography type="body3" className="w-[240px] text-center text-gray-600">
+                    {resultData.description}
+                  </Typography>
+                </div>
+              </article>
+
+              <article className="my-4xs flex w-full flex-col justify-center rounded-xl px-2xs">
+                <TempertaureBox
+                  buddy={resultData.buddy}
+                  trust={resultData.trust}
+                  love={resultData.love}
+                  talk={resultData.talk}
+                  temperature={resultData.temperature}
+                />
+              </article>
+
+              <article className="py-sm">
+                <ShareBox />
+              </article>
+              <div className="flex w-full gap-4xs px-2xs">
+                <Link href="/test" className="w-full">
+                  <Button width="full" className="bg-primary-200 text-primary-800 ">
+                    테스트 다시 하기
+                  </Button>
+                </Link>
+                <Link href="/test/result/total" className="w-full">
+                  <Button width="full" variant="secondary">
+                    전체 유형 보러가기
+                  </Button>
+                </Link>
               </div>
-            </article>
+            </>
           )}
 
-          {resultData ? (
-            <TempertaureBox
-              buddy={resultData.buddy}
-              trust={resultData.trust}
-              love={resultData.love}
-              talk={resultData.talk}
-              temperature={resultData.temperature}
-            />
-          ) : (
-            <Spinner />
-          )}
-
-          <article className="py-sm">
-            <ShareBox />
-          </article>
-          <div className="flex w-full gap-4xs px-2xs">
-            <Link href="/test" className="w-full">
-              <Button width="full" className="bg-primary-200 text-primary-800 ">
-                테스트 다시 하기
-              </Button>
-            </Link>
-            <Link href="/test/result/total" className="w-full">
-              <Button width="full" variant="secondary">
-                전체 유형 보러가기
-              </Button>
-            </Link>
-          </div>
-
-          {bestVoteContents && (
+          {bestVoteContents ? (
             <article className="w-full px-2xs pt-lg">
               <div className="flex  flex-col items-center gap-3xs">
                 <Typography type="heading3">투표로 더 많은 논쟁을 해결해봐요</Typography>
@@ -103,6 +101,34 @@ const ResultContents = ({ id }: { id: number }) => {
                         src={bestVoteContents.selections[1].imagePath}
                         alt="vote_item_image"
                       />
+                    </VoteItem>
+                  </VoteCard.VoteItemGroup>
+                </VoteCard>
+              </div>
+              <Link href="/vote">
+                <Button variant="primary" width="full">
+                  투표하고 축의금 논쟁 종결짓기
+                </Button>
+              </Link>
+            </article>
+          ) : (
+            <article className="w-full px-2xs pt-lg">
+              <div className="flex  flex-col items-center gap-3xs">
+                <Typography type="heading3">투표로 더 많은 논쟁을 해결해봐요</Typography>
+                <VoteCard className="w-full border-b-0">
+                  <VoteCard.Header categories="축의금" closeDate="2024-04-15" />
+                  <VoteCard.Description
+                    title="Q. 갑자기 연락온 동창 축의금 얼마할까요?"
+                    content="제목 그대로 학창시절 조금 친했던 친구였는데요. 지내다가 최근에 연락이 되었어요. 옛날 생각이 나네요... 그런데 얼마하는게 맞을까요?!"
+                  />
+                  <VoteCard.VoteItemGroup withBlur>
+                    <VoteItem readOnly>
+                      <VoteItem.Radio></VoteItem.Radio>
+                      <VoteItem.Text>5만원</VoteItem.Text>
+                    </VoteItem>
+                    <VoteItem readOnly>
+                      <VoteItem.Radio></VoteItem.Radio>
+                      <VoteItem.Text>10만원</VoteItem.Text>
                     </VoteItem>
                   </VoteCard.VoteItemGroup>
                 </VoteCard>

--- a/src/app/test/result/[id]/_components/TempertaureBox.tsx
+++ b/src/app/test/result/[id]/_components/TempertaureBox.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const TempertaureBox = ({ buddy, trust, love, talk, temperature }: Props) => {
   return (
-    <article className="my-4xs flex w-full flex-col justify-center rounded-xl px-2xs">
+    <>
       <div className="w-full rounded-t-xl  bg-primary-200 px-3xs  py-5xs text-center">
         <Typography type="title2">
           당신과 {buddy}의 온도는
@@ -50,7 +50,7 @@ const TempertaureBox = ({ buddy, trust, love, talk, temperature }: Props) => {
           </div>
         </div>
       </div>
-    </article>
+    </>
   );
 };
 

--- a/src/app/test/result/[id]/page.tsx
+++ b/src/app/test/result/[id]/page.tsx
@@ -1,3 +1,7 @@
+import { TEST } from '@/api/test';
+import { QUERY_KEY } from '@/constants/queryKey';
+import PrefetchHydration from '@/contexts/reactQuery/PrefetchHydration';
+
 import { ResultContents } from './_components';
 
 type Props = {
@@ -6,7 +10,15 @@ type Props = {
 
 const ResultPage = ({ params }: Props) => {
   const id = +params['id'];
-  return <ResultContents id={id} />;
+
+  return (
+    <PrefetchHydration
+      queryKey={QUERY_KEY.TEST.GET_RESULT_BY_ID(id)}
+      queryFn={() => TEST.GET_RESULT_BY_ID(id)}
+    >
+      <ResultContents id={id} />;
+    </PrefetchHydration>
+  );
 };
 
 export default ResultPage;

--- a/src/contexts/reactQuery/QueryClientProvider.tsx
+++ b/src/contexts/reactQuery/QueryClientProvider.tsx
@@ -12,6 +12,7 @@ const queryClientOption: QueryClientConfig = {
       refetchOnMount: false,
       refetchOnWindowFocus: false,
       networkMode: 'always',
+      staleTime: 60 * 1000,
     },
     mutations: {
       networkMode: 'always',


### PR DESCRIPTION
## ✨ 작업 내용
테스트 결과 페이지 진입시 이중 로딩을 제거하려고 합니다. 구현 과정은 다음과 같습니다. 
- 이전에 석진님께서 페이지는 서버 컴포넌트로 구현하는게 좋다고 하여 이전에 구조를 변경해놓았던게 도움이 됐습니다. 
- 서버 컴포넌트에서 데이터를 미리 가지고 옵니다.
```tsx
//src/app/test/result/[id]/page.tsx

  return (
    <PrefetchHydration
      queryKey={QUERY_KEY.TEST.GET_RESULT_BY_ID(id)}
      queryFn={() => TEST.GET_RESULT_BY_ID(id)}
    >
      <ResultContents id={id} />;
    </PrefetchHydration>
  );
};

export default ResultPage;
```

- 그 후 클라이언트 컴포넌트에서 useQuery를 활용하여 데이터를 가지고 오는데 isLoading과 isFetching을 활용하여 확인해보니 둘다 false로 사전에 가져와진 데이터를 보여주고 있는 것을 확인했습니다. 


## 📚 작업 결과
close #164 

이전

https://github.com/dnd-side-project/dnd-10th-3-frontend/assets/93697790/ab288a80-2311-4695-9edd-0f93d7d3de8b


이후 

https://github.com/dnd-side-project/dnd-10th-3-frontend/assets/93697790/5a619516-dca8-493d-bd4d-5e7d7445dea3

<!-- 없다면 적지 않으셔도 됩니다. -->
<!-- 사진이 있다면 함께 첨부해 주세요 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

## ✅ PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone을 등록했습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.
